### PR TITLE
prevents an exception being thrown

### DIFF
--- a/src/HTMLParser.php
+++ b/src/HTMLParser.php
@@ -183,6 +183,10 @@ class HTMLParser
         if (!$parseSuccessful) {
             return false;
         }
+        
+        if (!$result) {
+            return false;
+        }
 
         $result = $this->postProcessContent($result);
 


### PR DESCRIPTION
prevents an exception being thrown by postProcessContent() when $result is a bool not a DOM object. I have experienced this error.