### PR TITLE
Fix "Unsupported operand types"

### DIFF
--- a/src/HTMLParser.php
+++ b/src/HTMLParser.php
@@ -618,9 +618,10 @@ class HTMLParser
          * the original title.
          */
         $curTitleWordCount = count(preg_split('/\s+/', $curTitle));
+        $originalTitleWordCount = count(preg_split('/\s+/', preg_replace('/[\|\-\\\\\/>»]+/', '', $originalTitle))) - 1;
 
         if ($curTitleWordCount <= 4 &&
-            (!$titleHadHierarchicalSeparators || $curTitleWordCount !== preg_split('/\s+/', preg_replace('/[\|\-\\\\\/>»]+/', '', $originalTitle)) - 1)) {
+            (!$titleHadHierarchicalSeparators || $curTitleWordCount !== $originalTitleWordCount)) {
             $curTitle = $originalTitle;
         }
 


### PR DESCRIPTION
Hi!

I found an issue when parse [http://www.lemonde.fr/banques-finance-assurance/](http://www.lemonde.fr/banques-finance-assurance/).

`PHP Fatal error:  Uncaught Error: Unsupported operand types in vendor/andreskrey/readability.php/src/HTMLParser.php:622`

Seems to be a missing "count" in if statement.
