### PR TITLE
Fix PHP notice on DOMElement $parentOfTopCandidate.

### DIFF
--- a/src/Readability.php
+++ b/src/Readability.php
@@ -898,7 +898,7 @@ class Readability
             $scoreThreshold = $lastScore / 3;
 
             /* @var DOMElement $parentOfTopCandidate */
-            while ($parentOfTopCandidate->nodeName !== 'body') {
+            while ($parentOfTopCandidate->parentNode !== null && $parentOfTopCandidate->nodeName !== 'body') {
                 $parentScore = $parentOfTopCandidate->contentScore;
                 if ($parentScore < $scoreThreshold) {
                     break;


### PR DESCRIPTION
Hi Andres!

I have a notice when parse:
[http://www.uproxx.com/movies/everything-coming-to-leaving-netflix-january-2018](http://www.uproxx.com/movies/everything-coming-to-leaving-netflix-january-2018)
`PHP Notice: Trying to get property of non-object in /vendor/andreskrey/readability.php/src/Readability.php on line 901`

I'm not sure to understand exactly why parent node is "null", nevertheless can be fixed simply.

Thanks!  :)