### PR TITLE
Add missing DOM classes

### DIFF
--- a/src/Nodes/DOM/DOMDocument.php
+++ b/src/Nodes/DOM/DOMDocument.php
@@ -24,5 +24,6 @@ class DOMDocument extends \DOMDocument
         $this->registerNodeClass('DOMNotation', DOMNotation::class);
         $this->registerNodeClass('DOMProcessingInstruction', DOMProcessingInstruction::class);
         $this->registerNodeClass('DOMText', DOMText::class);
+        $this->registerNodeClass('DOMEntityReference', DOMEntityReference::class);
     }
 }

--- a/src/Nodes/DOM/DOMEntityReference.php
+++ b/src/Nodes/DOM/DOMEntityReference.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace andreskrey\Readability\Nodes\DOM;
+
+use andreskrey\Readability\Nodes\NodeTrait;
+
+class DOMEntityReference extends \DOMEntityReference
+{
+    use NodeTrait;
+}

--- a/test/test-pages/lemonde-2/expected-images.json
+++ b/test/test-pages/lemonde-2/expected-images.json
@@ -1,0 +1,1 @@
+["http:\/\/s1.lemde.fr\/medias\/web\/1.2.705\/img\/placeholder\/default.png"]

--- a/test/test-pages/lemonde-2/expected-metadata.json
+++ b/test/test-pages/lemonde-2/expected-metadata.json
@@ -1,0 +1,1 @@
+{"Title":"La crise europ\u00e9enne est une crise de la dette, pas de l'euro","Author":null,"Excerpt":"Le retour \u00e0 la stabilit\u00e9 co\u00fbtera des milliards d'euros, mais l'Union europ\u00e9enne en vaut la peine, estime un collectif d'industriels."}

--- a/test/test-pages/lemonde-2/source.html
+++ b/test/test-pages/lemonde-2/source.html
@@ -1,0 +1,1353 @@
+<!doctype html>
+<!--[if lt IE 9]><html class="ie"><![endif]-->
+<!--[if IE 9]><html class="ie9"><![endif]-->
+<!--[if gte IE 9]><!-->
+<html lang="fr">
+<!--<![endif]-->
+
+<head>
+<script type="text/javascript">
+var kameleoonLoadingTimeout = 1000;
+var kameleoonStartLoadTime = new Date().getTime();
+if (!document.getElementById("kameleoonLoadingStyleSheet") && !window.kameleoonDisplayPageTimeOut) {
+    var kameleoonS = document.getElementsByTagName("script")[0];
+    var kameleoonCc = "* { visibility: hidden !important; background-image: none !important; }";
+    var kameleoonStn = document.createElement("style");
+    kameleoonStn.type = "text/css";
+    kameleoonStn.id = "kameleoonLoadingStyleSheet";
+    if (kameleoonStn.styleSheet) {
+        kameleoonStn.styleSheet.cssText = kameleoonCc;
+    } else {
+        kameleoonStn.appendChild(document.createTextNode(kameleoonCc));
+    }
+    kameleoonS.parentNode.insertBefore(kameleoonStn, kameleoonS);
+    window.kameleoonDisplayPage = function() {
+        if (kameleoonStn.parentNode) {
+            kameleoonStn.parentNode.removeChild(kameleoonStn);
+        }
+    };
+    window.kameleoonDisplayPageTimeOut = window.setTimeout(window.kameleoonDisplayPage, kameleoonLoadingTimeout);
+}
+</script>
+<script src="//static.kameleoon.com/css/customers/r9u0567aww/0/kameleoon.js" async></script>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MS62MT');</script>
+<!-- End Google Tag Manager -->
+
+
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+
+<script>
+if("undefined"===typeof lmd||!lmd)lmd={};(function(a,b){var d=a.onerror,c="";a.onerror=function(a,e,f){d&&d.apply(this,[a,e,f]);c=e+" line:"+f+" : "+a;"undefined"!==typeof b.jserrors&&"function"===typeof b.jserrors.push?10>=b.jserrors.length&&b.jserrors.push(c):b.jserrors=[c]}})(this,lmd);
+</script>
+
+
+<!-- context -->
+<script>if("undefined"===typeof lmd||!lmd)lmd={};lmd.context={"pageType":"Element","rubrique":{"id":3232,"url_friendly":"idees","parents":[],"rubrique_ombrelle":{"id":3232,"url_friendly":"idees"},"maquette":"technologies_home"},"rubriques":[{"id":3232,"url_friendly":"idees"}],"element":{"id":1538337,"cms_id":null,"titre":"La crise europ\u00e9enne est une crise de la dette, pas de l'euro","gabarit":"colright","partenaire":null,"nature_editoriale":{"id":2,"nom":"point_de_vue","libelle":"Point de vue"},"type":{"id":4,"nom":"article","libelle":"Article","est_en_continu":true,"est_editorial":true,"icon":"article"},"restreint":false,"url_friendly":"la-crise-europeenne-est-une-crise-de-la-dette-pas-de-l-euro","link":"\/idees\/article\/2011\/06\/20\/la-crise-europeenne-est-une-crise-de-la-dette-pas-de-l-euro_1538337_3232.html","facebook_likes":368,"ensemble":{"id":1539151,"tetiere":"D\u00e9bats de la semaine : respect !"},"nb_signes":5017,"has_atome_video":false},"campagne":null,"page":{"advert":{"active":true,"colonne_light":false,"adserver":"smartadserver","smart":{"site":"50270","page":361507,"query":null,"all_formats":"21489,21490,21935,21486,21482,21488,21483,21484,21485,25258,25259,25260,21936,21487,21492,21493,21938,21937,23371,23885,15187,15188,29752,29753,27863,25553,25553,26077,26076,26333,25551,26078,25550,25550,22379,26080,26613,22380,27863,25553,25553,26077,26076,26333,25551,26078,25550,25550,22379,26080,26613,22380,21488","domain":"ww690.smartadserver.com","render_mode":0}},"dfp":{"tag":"\/128139881\/LM_lemonde\/idees\/idees\/article\/","formats":"{\"inread\":{\"desktop\":[[\"fluid\"],[2,2],[533,300]]},\"cover\":{\"desktop\":[[1,1]]},\"pave_milieu\":{\"desktop\":[[300,600],[300,250]]},\"pave_haut\":{\"desktop\":[[300,250],[300,600],[300,800],[300,900],[300,1000],[300,1050]]},\"pave_bas\":{\"desktop\":[[300,250]]},\"partenaire_middle\":{\"desktop\":[[\"fluid\"],[1,1]]},\"partenaire_bottom\":{\"desktop\":[[\"fluid\"],[1,1]]},\"parallaxe\":{\"desktop\":[[\"out-of-page\"]]},\"oreille_droite\":{\"desktop\":[[300,60]]},\"habillage\":{\"desktop\":[[\"out-of-page\"]]},\"dhtml\":{\"desktop\":[[\"out-of-page\"]]},\"banniere_haute\":{\"desktop\":[[728,90],[970,250],[\"970 \",90],[1000,90],[1000,200],[1000,300],[1000,350],[1000,400],[1000,450],[1000,500],[468,60]]},\"banniere_basse\":{\"desktop\":[[728,90],[1000,90],[468,60]]}}","device":"desktop","section":"idees"},"xiti":{"xtpage":"idees::la_crise_europeenne_est_une_crise_de_la_dette_pas_de_l_euro","xtpagetype":null,"xtn2":53,"xtsite":"43260","xt_multc":"&x1=&x2=article","xt_abmv":null,"xt_chains":null,"xtcustom":{},"xt_tag":null,"xtergo":null,"xtsites":{"www":"43260","mobile":"489989"},"xtbreakpoints":{"www":{"min":768},"mobile":{"min":0,"max":767}},"x12":null,"x2":null,"x5":null}},"application":"www"};lmd.context.item = lmd.context.element;</script>
+
+<!-- Mobile redirect, lmd conf, registered redirect -->
+<script src="//s1.lemde.fr/bootstrap/list-early-load.js"></script>
+
+<title>La crise europ&eacute;enne est une crise de la dette, pas de l'euro</title>
+
+<meta name="description" content="Le retour &agrave; la stabilit&eacute; co&ucirc;tera des milliards d'euros, mais l'Union europ&eacute;enne en vaut la peine, estime un collectif d'industriels.">
+<meta name="robots" content="index, follow, noarchive">
+
+
+<meta http-equiv="refresh" content="900">
+
+<meta http-equiv="Expires" content="0">
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+<meta name="application-name" content="Le Monde.fr">
+<meta name="DC.language" content="fr">
+<meta name="DC.format" content="text/html">
+<meta name="DC.publisher" content="Le Monde">
+<meta name="DC.identifier" content="ISSN 1950-6244">
+
+<meta name="msapplication-tooltip" content="Le Monde.fr">
+<meta name="msapplication-navbutton-color" content="#000">
+<meta name="msapplication-starturl" content="/">
+<meta name="msapplication-task" content="name=A la Une;action-uri=/;icon-uri=/medias/web/ico/ie9-pin/une.ico">
+<meta name="msapplication-task" content="name=International;action-uri=/international/;icon-uri=/medias/web/ico/ie9-pin/international.ico">
+<meta name="msapplication-task" content="name=Politique;action-uri=/politique/;icon-uri=/medias/web/ico/ie9-pin/politique.ico">
+<meta name="msapplication-task" content="name=Economie;action-uri=/economie/;icon-uri=/medias/web/ico/ie9-pin/economie.ico">
+<meta name="msapplication-task" content="name=Sport;action-uri=/sport/;icon-uri=/medias/web/ico/ie9-pin/sport.ico">
+
+
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="//s1.lemde.fr/medias/web/1.2.705/ico/apple/icon-72.png">
+<link rel="apple-touch-icon-precomposed" sizes="144x144" href="//s1.lemde.fr/medias/web/1.2.705/ico/apple/icon-144.png">
+
+<meta property="fb:app_id" content="166878320861">
+<meta property="fb:page_id" content="14892757589">
+
+	<meta property="og:site_name" content="Le Monde.fr" />
+	<meta property="og:locale" content="fr_FR" />
+	<meta property="og:title" content="La crise européenne est une crise de la dette, pas de l'euro" />
+	<meta property="og:description" content="Le retour à la stabilité coûtera des milliards d'euros, mais l'Union européenne en vaut la peine, estime un collectif d'industriels." />
+	<meta property="og:url" content="http://www.lemonde.fr/idees/article/2011/06/20/la-crise-europeenne-est-une-crise-de-la-dette-pas-de-l-euro_1538337_3232.html" />
+	<meta property="og:type" content="article" />
+	<meta property="og:image:type" content="image/png" />
+	<meta property="og:image:width" content="1880" />
+	<meta property="og:image:height" content="984" />
+	<meta property="og:image" content="http://s1.lemde.fr/medias/web/1.2.705/img/placeholder/default.png" />
+
+<meta property="al:ios:url" content="lmfr://element/article/1538337?x4=8&amp;xto=AL-8-%5BAutres%5D">
+<meta property="al:ios:app_store_id" content="294047850">
+<meta property="al:ios:app_name" content="Le Monde, l'info en continu">
+<meta property="al:android:url" content="lmfr://element/article/1538337?x4=8&amp;xto=AL-8-%5BAutres%5D">
+<meta property="al:android:package" content="com.lemonde.androidapp">
+<meta property="al:android:app_name" content="Le Monde, l'info en continu">
+<meta property="al:web:url" content="http://www.lemonde.fr/idees/article/2011/06/20/la-crise-europeenne-est-une-crise-de-la-dette-pas-de-l-euro_1538337_3232.html">
+<meta property="al:web:should_fallback" content="true">
+<meta name="apple-itunes-app" content="app-id=294047850, affiliate-data=11lteT, app-argument=lmfr://element/article/1538337?x4=8&amp;xto=AL-8-%5BiOS_Banner%5D">
+<link rel="alternate" href="android-app://com.lemonde.androidapp/lmfr/element/article/1538337?x4=8" />
+<link rel="alternate" href="ios-app://294047850/lmfr/element/article/1538337?x4=8" />
+
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@lemondefr">
+<meta name="twitter:url" content="http://www.lemonde.fr/idees/article/2011/06/20/la-crise-europeenne-est-une-crise-de-la-dette-pas-de-l-euro_1538337_3232.html">
+<meta name="twitter:title" content="La crise européenne est une crise de la dette, pas de l'euro">
+<meta name="twitter:description" content="Le retour à la stabilité coûtera des milliards d'euros, mais l'Union européenne en vaut la peine, estime un collectif d'industriels.">
+
+
+
+<link rel="shortcut icon" href="//s1.lemde.fr/medias/web/1.2.705/ico/favicon.ico">
+<link rel="stylesheet" type="text/css" href="//s1.lemde.fr/bootstrap/www/8855f2ced6b0cd074585e4d4d0f2d8c4.css?m[]=normalize%40screen&m[]=fonts%40screen&m[]=grille%40screen&m[]=base%40screen&m[]=header%40screen&m[]=footer%40screen&m[]=rubrique%40screen&m[]=article%40screen&m[]=friends%2Fpaves%40screen&m[]=col_droite%40screen&m[]=ticker%40screen&m[]=couleurs%40screen&m[]=marketing%2Fmeter%40screen&m[]=evenementiel%2Fcoupe-du-monde%40screen&m[]=elections%2Famericaines%40screen&m[]=friends%2Fnewsweb%2Fbase%40screen&m[]=friends%2Fnewsweb%2Fdatabox%40screen&m[]=friends%2Fnewsweb%2Flivescore%40screen&m[]=friends%2Fnewsweb%2Flivescore_tennis%40screen&m[]=%2F%2Fasset.lemde.fr%2Fdata%2F0.17.0%2Fcss%2Fcadre-page%40screen&m[]=print%40print&m[]=element%40screen&m[]=modules%2Fportfolio%40screen&m[]=modules%2Fzen%40screen&m[]=abonnes%2Foverlay%40screen&m[]=friends%2Fione%40screen&m[]=modules%2Fmultimedia-embed%40screen">
+
+        <link rel="canonical" href="http://www.lemonde.fr/idees/article/2011/06/20/la-crise-europeenne-est-une-crise-de-la-dette-pas-de-l-euro_1538337_3232.html">
+        <link rel="alternate" href="http://mobile.lemonde.fr/idees/article/2011/06/20/la-crise-europeenne-est-une-crise-de-la-dette-pas-de-l-euro_1538337_3232.html" media="only screen and (max-width: 640px)">
+<link rel="alternate" href="http://www.lemonde.fr/idees/rss_full.xml" title="Le Monde.fr : Id&eacute;es" type="application/rss+xml">
+
+
+<script src="//s1.lemde.fr/medias/web/1.2.705/js/lib/require/core/current/require.js"></script>
+<script src="//s1.lemde.fr/bootstrap/www/main.js"></script>
+
+<script>
+   if(-1 === requirejs.s.contexts._.config.baseUrl.indexOf('lemde'))
+   {
+      require = function(){};
+   }
+</script>
+
+
+<script>
+"undefined"!==typeof lmd&&lmd||(lmd={});
+(function(e,d){var f=function(b,a){var c;if(void 0===a||null===a||""===a)return!0;for(c=0;c<b.requireModules.length;c++)if(b.requireModules[c].match(a))return!0;return!1},g=function(b,a){var c;for(c=0;c<d.requirejs.error_history.length;c++)f(d.requirejs.error_history[c],a)&&b.call(this,d.requirejs.error_history[c])},h=function(b){var a,c=d.requirejs.handlers;for(a=0;a<c.length;a++)f(b,c[a].regex)&&c[a].fn.call(this,b)};d.requirejs={handlers:[],error_history:[],addHandler:function(b,a,c){"undefined"!==
+typeof c&&c&&g(b,a);d.requirejs.handlers.push({fn:b,regex:a})}};requirejs.onError=function(b){var a=b.originalError&&b.originalError.target||{};h(b);d.requirejs.error_history.push(b);if("function"===typeof e.onerror)e.onerror("REQUIRE ERROR ("+b.requireType+") ["+a.src+"]",a.baseURI,"N/A");else throw b;}})(this,lmd);
+</script>
+
+
+<!--[if IE]>
+    <script src="//s1.lemde.fr/medias/web/1.2.705/js/lib/ecma/core/262/base64.js"></script>
+<![endif]-->
+<!--[if lte IE 9]>
+   <script src="//s1.lemde.fr/medias/web/1.2.705/js/lib/polyfill/placeholder.js"></script>
+<![endif]-->
+<!--[if lt IE 9]>
+   <script src="//s1.lemde.fr/medias/web/1.2.705/js/lib/html5shiv/html5.js"></script>
+   <script src="//s1.lemde.fr/medias/web/1.2.705/js/lib/ecma/core/262/array.js"></script>
+<![endif]-->
+<!--[if lte IE 8]>
+<![endif]-->
+
+<!--[if lte IE 7]>
+   <script src="//s1.lemde.fr/medias/web/1.2.705/js/lib/ecma/core/262/json.js"></script>
+<![endif]-->
+<script>require(['lmd.afrique.cookie']);</script>
+
+<script>
+   (function (d) {
+      var script = d.createElement('script');
+      var trange = (new Date()).getTime().toString().slice(0, -5);
+      script.src = '//s1.lemde.fr/medias/web/1.2.705/js/lmd/module/meter/toggle-off.js?' + trange;
+      d.write(script.outerHTML);
+   })(document);
+
+   require(['lmd.meter'], function (loader) {
+      loader.launch();
+   });
+</script>
+<script>
+
+var _vrq = _vrq || [];
+_vrq.push(['id',53]);
+_vrq.push(['track',function(){}]);
+if(lmd.conf.fsw.visual_revenue && document.location.protocol=== "http:"){require(["http://a.visualrevenue.com/vrs.js"]);}
+</script>
+
+
+<script>var _sf_startpt = (new Date()).getTime()</script>
+
+<script>
+require(["lib/require/plugin/domReady","lmd/util/link"],function(a,b){a(function(){b.parse()})});
+
+</script>
+
+<script>if("undefined"===typeof lmd||!lmd)lmd={};lmd.pic=function(a){require(["lmd/module/retina"],function(b){b(a)})};lmpic=lmd.pic;</script><script>
+    if (typeof lmd === 'undefined' || !lmd) {
+        lmd = {};
+    }
+
+    lmd.onload = function(fn) {
+        if (document.readyState !== 'loading') {
+            fn();
+        } else if (document.addEventListener) {
+            document.addEventListener('DOMContentLoaded', fn);
+        } else {
+            document.attachEvent('onreadystatechange', function() {
+                if (document.readystate !== 'loading') {
+                    fn();
+                }
+            });
+        }
+    };
+
+    _lmOnload = lmd.onload;
+</script>
+
+<script>
+   require(['lmd/core/login-register']);
+</script>
+<script>require(['lmd/core/crm'], function (crm) { crm.increment(); });</script>
+
+
+<!--[if IE]>
+<script>require(["lib/require/plugin/domReady!","lmd/ui/ie9-pinning"],function(b,a){a.start()});</script>
+<![endif]-->
+
+<link rel="dns-prefetch" href="//logc2.xiti.com">
+
+
+<script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"NewsArticle","mainEntityOfPage":{"@type":"WebPage","@id":"http:\/\/www.lemonde.fr\/idees\/article\/2011\/06\/20\/la-crise-europeenne-est-une-crise-de-la-dette-pas-de-l-euro_1538337_3232.html"},"headline":"La crise europ\u00e9enne est une crise de la dette, pas de l'euro","dateCreated":"2011-06-20T13:01:05+0200","datePublished":"2011-06-20T13:32:32+0200","publisher":{"@type":"Organization","name":"Le Monde","logo":{"@type":"ImageObject","url":"http:\/\/s1.lemde.fr\/medias\/web\/1.2.705\/img\/elements_lm\/logo_lm_print.png","width":"240","height":"42"}},"dateModified":"2011-06-22T10:28:28+0200","description":"Le retour \u00e0 la stabilit\u00e9 co\u00fbtera des milliards d'euros, mais l'Union europ\u00e9enne en vaut la peine, estime un collectif d'industriels.","author":{"@type":"Person","name":"Collectif"}}</script>
+</head>
+<body class="site-gratuit idees">
+    <!-- Google Tag Manager No Script -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-MS62MT"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager No Script -->
+    <div id="dfp-cover" class="dfp_slot" data-format="cover" style="display:none;"></div>
+
+    
+    <header id="header-page">
+    <div id="surheader">
+    <div class="contenu">
+        <div class="groupe">
+            <a href="/" title="Le Monde" target="_self">Le Monde</a>
+            <a href="http://www.telerama.fr/" title="T&eacute;l&eacute;rama" target="_blank">T&eacute;l&eacute;rama</a>
+            <a href="http://www.monde-diplomatique.fr/" title="Le Monde diplomatique" target="_blank">Le Monde diplomatique</a>
+            <a href="http://www.huffingtonpost.fr/" title="HuffPost" target="_blank">HuffPost</a>
+            <a href="http://www.courrierinternational.com/" title="Courrier international" target="_blank">Courrier international</a>
+            <a href="http://www.lavie.fr/" title="La Vie" target="_blank">La Vie</a>
+            <a href="https://tempsreel.nouvelobs.com/" title="L'Obs" target="_blank">L'Obs</a>
+        </div>
+        <div class="partners">
+            <a class="partners__link" target="_blank" href="http://codepromo.lemonde.fr/" title="Codes promo" onclick="return xt_click(this, 'C', '', 'Cuponation_sur_header', 'N')">Codes promo</a>
+        </div>
+        <div class="services">
+            <span>Services Le Monde ▾</span>
+            <div>
+                <div>
+                    <strong>Partenaires Le Monde</strong>
+                    <a href="http://voiture-occasion.lemonde.fr" title="Annonces auto" target="_self">Annonces auto</a>
+                    <a href="http://offres.offres-emploi.monster.fr/?ch=LEMONDE" title="Annonces emploi" target="_blank">Annonces emploi</a>
+                    <a href="http://immobilier.lemonde.fr/" title="Annonces immo" target="_self">Annonces immo</a>
+                    <a href="http://codepromo.lemonde.fr/" title="Codes promo" target="_blank">Codes promo</a>
+                    <a href="http://dicocitations.lemonde.fr/" title="Citations" target="_self">Citations</a>
+                    <a href="http://anglais.lemonde.fr/" title="Cours d&rsquo;anglais" target="_self">Cours d&rsquo;anglais</a>
+                    <a href="https://formation-professionnelle.lemonde.fr/" title="Formation professionnelle" target="_self">Formation professionnelle</a>
+                    <a href="https://jardinage.lemonde.fr/" title="Jardinage" target="_self">Jardinage</a>
+                    <a href="http://modele-lettre.lemonde.fr/" title="Mod&egrave;les de lettres" target="_self">Mod&egrave;les de lettres</a>
+                    <a href="http://progresser-orthographe.lemonde.fr/" title="Orthographe" target="_self">Orthographe</a>
+                    <a href="http://paroles2chansons.lemonde.fr/" title="Paroles de chansons" target="_self">Paroles de chansons</a>
+                    <a href="http://prix-immobilier.lemonde.fr/prix-immobilier/" title="Prix de l&rsquo;immobilier" target="_self">Prix de l&rsquo;immobilier</a>
+                    <a href="http://encheres.lemonde.fr" title="Ventes aux ench&egrave;res" target="_self">Ventes aux ench&egrave;res</a>
+                </div>
+
+                <div>
+                    <strong>Boutique Le Monde</strong>
+                    <a href="http://boutique.lemonde.fr/#xtor=AD-46" title="Accueil" target="_blank">Accueil</a>
+                    <a href="http://boutique.lemonde.fr/hors-series.html#xtor=AD-101" title="Hors-S&eacute;ries" target="_blank">Hors-S&eacute;ries</a>
+                    <a href="http://boutique.lemonde.fr/livres.html#xtor=AD-100" title="Livres" target="_blank">Livres</a>
+                    <a href="http://boutique.lemonde.fr/dvd-1.html#xtor=AD-98" title="DVD" target="_blank">DVD</a>
+                    <a href="http://boutique.lemonde.fr/cd.html#xtor=AD-99" title="CD" target="_blank">CD</a>
+                    <a href="http://boutique.lemonde.fr/unes-du-monde.html#xtor=AD-149" title="Unes du Monde" target="_blank">Unes du Monde</a>
+                    <a href="http://boutique.lemonde.fr/loisirs-et-papeterie.html#xtor=AD-103" title="Loisirs & papeterie" target="_blank">Loisirs & papeterie</a>
+                    <a href="http://boutique.lemonde.fr/promos.html#xtor=AD-345" title="Promotions" target="_blank">Promotions</a>
+                </div>
+            </div>
+        </div>
+
+        <div class="abonnement">
+<a title="Abonnez-vous au Monde à partir de 1 €" href="https://abo.lemonde.fr#xtor=CS1-263[BOUTONS_LMFR]-[HEADER]-53-[Article]" onclick="return xt_click(this, 'C', '', 'Abo::Header', 'N')" rel="nofollow">
+                <span>S’abonner au Monde à partir de 1 €</span>
+            </a>        </div>
+    </div>
+</div>
+    <div id="header-utilisateur">
+        <div class="contenu">
+            <a class="logo" href="/"></a>
+            <div class="menu-edition">
+                <ul>
+                    <li>
+                        <a href="#" title="Édition globale">
+                            Édition globale ▾
+                        </a>
+                    </li>
+                    <li>
+                        <a href="/afrique/" title="Édition afrique">
+                            Édition afrique
+                        </a>
+                    </li>
+                </ul>
+            </div>
+            <div class="liens-utilisateur">
+                <div class="partages">
+                    <ul>
+                        <li>
+                            <a href="http://www.facebook.com/lemonde.fr" title="Facebook" target="" class="svg-facebook svg-facebook-dims">
+                                Facebook
+                            </a>
+                        </li>
+                        <li>
+                            <a href="http://twitter.com/lemondefr" title="Twitter" target="" class="svg-twitter svg-twitter-dims">
+                                Twitter
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://plus.google.com/+LeMondefr" title="Google+" target="" class="svg-google svg-google-dims">
+                                Google+
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://www.instagram.com/lemondefr/" title="Instagram" target="_blank" class="svg-instagram">
+                                Instagram
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="recherche">
+                    <a href="/recherche/" class="recherche__link">Rechercher</a>
+                </div>
+                <div class="liens-services">
+                    <a href="/emploi/" title="Emploi" target="" class="emploi">
+                        Emploi
+                    </a>
+                    <a href="https://secure.lemonde.fr/sfuser/newsletters" title="Newsletters" target="" class="newsletters">
+                        Newsletters
+                    </a>
+                </div>
+                <div class="liens-connexion">
+                    <ul>
+                        <li>
+                            <a href="https://secure.lemonde.fr/sfuser/register" title="S'inscrire" target="" class="sinscrire">
+                                S'inscrire
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://secure.lemonde.fr/sfuser/connexion" title="Connexion" target="" class="connexion">
+                                Connexion
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</header>
+
+<script>
+    require(['lmd/module/header']);
+</script>
+
+<div class="fixed-header">
+    <div class="fixed-header-content">
+        <a class="fixed-header-logo" href="/"></a>
+        <div class="fixed-header-title">La crise européenne est une crise de la dette, pas de l'euro</div>
+        <div class="fixed-header-sharing-buttons">
+            <div data-sharewith="facebook" data-xiti-label="Partage::Facebook::La crise européenne est une crise de la dette, pas de l'euro::header">Partager<span class="fixed-header-facebook-likes-counter"></span></div>
+            <div data-sharewith="twitter" data-xiti-label="Partage::Twitter::La crise européenne est une crise de la dette, pas de l'euro::header">Tweeter</div>
+            <div data-sharewith="google-plus" data-xiti-label="Partage::Google+::La crise européenne est une crise de la dette, pas de l'euro::header"></div>
+            <div data-sharewith="linkedin" data-xiti-label="Partage::Linkedin::La crise européenne est une crise de la dette, pas de l'euro::header"></div>
+            <div data-sharewith="pinterest" data-xiti-label="Partage::Pinterest::La crise européenne est une crise de la dette, pas de l'euro::header"></div>
+        </div>
+    </div>
+</div>
+
+<script>
+    require(['lmd/module/fixed-header'], function (fixedHeader) {
+            'use strict';
+            fixedHeader.init();
+        }
+    );
+</script>
+
+<div id="alerte_tracking" class="bandeau_info_importante bord_gris_moyen" style="display:none;height:0;">
+  En poursuivant votre navigation sur ce site, vous acceptez nos <a href="http://www.lemonde.fr/cgv">CGV</a> et l’utilisation de cookies pour vous proposer des contenus et services adaptés à vos centres d’intérêts et vous permettre l'utilisation de boutons de partages sociaux.
+   <a href="http://www.lemonde.fr/service/donnees_personnelles.html">En savoir plus et gérer ces paramètres</a>.
+   <span class="croix_grise mgl8" title="Fermer cet avertissement"></span>
+</div>
+<script>require(["lmd/module/user/alerte_tracking"]);</script>
+
+
+    
+    <div id="habillagepub">
+    <script>
+require(["lmd/core/auth", "lmd/ui/header/header"], function(a,b){a.loadUser().done(function(){b.init();})});
+require(["lmd/module/acces-non-abonne"],function(a){a.init();});
+</script>
+                <div id="dfp-habillage" class="dfp_slot" data-format="habillage"></div>
+
+       <div id="dfp-banniere_haute" class="dfp_slot top banniere" data-format="banniere_haute"></div>
+
+
+
+
+    <div id="nav-section" class="section-page">
+<div class="conteneur-nav" id="nav">
+    <nav id="navigation-generale">
+        <span role="button" data-toggle="#navigation-generale ul" data-toggleRoot=".ecran.idees">Rubriques</span>
+        <ul>
+            <li class="accueil  ">
+                <a href="/" data-bypass="false" data-rubrique-title="A la une" data-rubrique-id="3208"  >
+                    <i class="maison">Accueil</i>
+                </a>
+            </li>
+            <li class="international  ">
+                <a href="/international/" data-bypass="false" data-rubrique-title="International" data-rubrique-id="3210"  >
+                    International
+                </a>
+            </li>
+            <li class="politique  ">
+                <a href="/politique/" data-bypass="false" data-rubrique-title="Politique" data-rubrique-id="823448"  >
+                    Politique
+                </a>
+            </li>
+            <li class="societe  ">
+                <a href="/societe/" data-bypass="false" data-rubrique-title="Société" data-rubrique-id="3224"  >
+                    Société
+                </a>
+            </li>
+            <li class="economie  ">
+                <a href="/economie/" data-bypass="false" data-rubrique-title="Économie" data-rubrique-id="3234"  >
+                    Éco
+                </a>
+            </li>
+            <li class="culture  ">
+                <a href="/culture/" data-bypass="false" data-rubrique-title="Culture" data-rubrique-id="3246"  >
+                    Culture
+                </a>
+            </li>
+            <li class="idees  alt">
+                <a href="/idees/" data-bypass="false" data-rubrique-title="Idées" data-rubrique-id="3232"  >
+                    Idées
+                </a>
+            </li>
+            <li class="planete  ">
+                <a href="/planete/" data-bypass="false" data-rubrique-title="Planète" data-rubrique-id="3244"  >
+                    Planète
+                </a>
+            </li>
+            <li class="sport  ">
+                <a href="/sport/" data-bypass="false" data-rubrique-title="Sport" data-rubrique-id="3242"  >
+                    Sport
+                </a>
+            </li>
+            <li class="sciences  ">
+                <a href="/sciences/" data-bypass="false" data-rubrique-title="Sciences" data-rubrique-id="1650684"  >
+                    Sciences
+                </a>
+            </li>
+            <li class="pixels  ">
+                <a href="/pixels/" data-bypass="false" data-rubrique-title="Pixels" data-rubrique-id="4408996"  >
+                    Pixels
+                </a>
+            </li>
+            <li class="campus  ">
+                <a href="/campus/" data-bypass="false" data-rubrique-title="Campus" data-rubrique-id="4401467"  >
+                    Campus
+                </a>
+            </li>
+            <li class="m-mag  ">
+                <a href="/m-le-mag/" data-bypass="false" data-rubrique-title="M le mag" data-rubrique-id="4500055"  >
+                    Le Mag
+                </a>
+            </li>
+            <li class="abonnes js_carousel_exclude ">
+                <a href="/teaser/presentation.html#xtor=CS1-263[BOUTONS_LMFR]-[BARRE_DE_NAV]-53-[Article]"  data-rubrique-title="Édition Abonnés" data-rubrique-id="1667658" onclick="return xt_click(this, 'C', '', 'Abo::Barre_de_nav', 'N');" rel="nofollow">
+                    Édition Abonnés
+                </a>
+            </li>
+            <li class="burger js_carousel_exclude">
+                <span role="button" title="afficher plus de rubriques" data-toggle="#navigation-generale .burger div" data-toggleRoot=".ecran.idees"></span>
+                <div data-toggle-policy="autoclear">
+                    <span>PLUS DE RUBRIQUES</span>
+                    <a href="/grands-formats/">Grands Formats</a>
+                    <a href="/les-decodeurs/">Les d&eacute;codeurs</a>
+                    <a href="/videos/">Vid&eacute;os</a>
+                    <a href="/data/">Données du Monde</a>
+                </div>
+            </li>
+        </ul>
+    </nav>
+</div>
+
+<script>
+    require(['jquery'], function($) {
+        $("#nav li").on('click', onNavItemClick);
+
+        function onNavItemClick(event) {
+            var classAttr,
+                className,
+                prefixXiti;
+
+            classAttr = $(event.target).closest("li").attr("class");
+            // If li tag has no class attributes or if class attribute is empty
+            if ($.trim(classAttr).length === 0) {
+                return;
+            }
+
+            className = classAttr.split(/\s+/)[0];
+            prefixXiti = (lmd.context.application === "www" ? "barre_nav_" : "barre_nav_abo_");
+            if (typeof xt_click === "function") {
+                xt_click(this, 'C', lmd.context.page.xiti.xtn2, prefixXiti + className, 'N');
+            }
+        }
+   });
+</script>
+
+</div>
+
+
+    <div class="ombrelle idees ombrelle_idees">
+   <div class="tt_rubrique_ombrelle"><span class="m_titre"></span><span class="couleur_rubrique obf" data-href="L2lkZWVzLw==">Idées</span></div>
+      <span class="widget">
+   <div id="widget_container" data-uri="/ajah/5m/lemonde/web/Controller_Module_Widget_PromoEdito/actionAfficher/WzM/yMz/Jd/EMPTY/?key=63bf535d68cc411839d1f411776b3792d6fe463b">
+           <div id="dfp-oreille_droite" class="dfp_slot" data-format="oreille_droite"></div>
+   </div>
+</span>
+</div>
+
+    <div id="ariane-context-3232">
+   <div class="clearall" id="ariane_az">
+      <nav id="nav_ariane" class="idees">
+         <ul>
+            <li class="ariane z1 actif">
+                                                         <a href="/idees/">Id&eacute;es</a>
+                           </li>
+                                    <li class="sous_rub">
+               <a href="/idees-tribunes/">Tribunes</a>
+            </li>
+            <li class="sous_rub">
+               <a href="/idees-enquetes/">Enqu&ecirc;tes</a>
+            </li>
+            <li class="sous_rub">
+               <a href="/idees-rencontres/">Rencontres</a>
+            </li>
+            <li class="sous_rub">
+               <a href="/controverses/">Controverses</a>
+            </li>
+            <li class="sous_rub">
+               <a href="/idees-livres/">Livres</a>
+            </li>
+            <li class="sous_rub">
+               <a href="/analyses/">Analyses</a>
+            </li>
+            <li class="sous_rub">
+               <a href="/editoriaux/">Editoriaux</a>
+            </li>
+            <li class="sous_rub">
+               <a href="/idees-chroniques/">Chroniques</a>
+            </li>
+            <li class="sous_rub">
+               <a href="/blogs/">Blogs</a>
+            </li>
+         </ul>
+         <div class="az" style="display:none;">
+            <span class="bt_ouvrir">&nbsp;</span>
+         </div>
+      </nav>
+      <div class="suite_entrees">
+         <p class="entrees">
+         </p>
+      </div>
+   </div>
+</div>
+<script>
+require(["lmd/ui/liste-az"],function(a){a.init({context:'#ariane-context-3232'})});
+</script>
+
+    
+    <div class="global meter_global js_meter_global">
+
+
+    <div class="top_container_article">
+        
+    </div>
+
+    <div class="container_18 clearfix">
+        <div class="grid_12 alpha">
+            <div class="applat_contenu">
+                <div class="grid_10 alpha prefix_1 suffix_1 col_gauche article_wrapper"><!-- col gauche -->
+
+                    <article class="article article_normal">
+                                                
+
+                        <h1 class="tt2" itemprop="Headline">La crise europ&eacute;enne est une crise de la dette, pas de l'euro</h1>
+
+                        <p class="txt3 description-article" itemprop="description">Le retour &agrave; la stabilit&eacute; co&ucirc;tera des milliards d'euros, mais l'Union europ&eacute;enne en vaut la peine, estime un collectif d'industriels.</p>
+
+
+                        <p class="bloc_signature">
+   <span id="publisher" itemprop="Publisher" data-source="LE MONDE">Le Monde</span>
+ |    <time datetime="2011-06-20T13:32:32+02:00"
+		itemprop="datePublished">20.06.2011 &agrave; 13h32</time>
+ • Mis à jour le
+<time datetime="2011-06-22T10:28:28+02:00"
+		itemprop="dateModified">22.06.2011 &agrave; 10h28</time>
+    |
+<span class="signature_article">
+Par      <span itemprop="author" class="auteur txt2_120">Collectif</span>
+</span>
+
+</p>
+
+
+                        <div class="toolbar"></div>
+
+                        
+
+                        <div id="articleBody" class="contenu_article js_article_body" itemprop="articleBody">
+                                                                                                                <h2 class="taille_courante">L'union monétaire s'enlise dans la crise, l'euro reste soumis au feu des critiques. C'est le bilan des nombreux <a class="lien_interne rub" href="http://www.lemonde.fr/afrique-debats/" title="Toute l’actualité débats">débats</a> qui ont eu lieu ces derniers mois.</h2>
+<p>En tant qu'industriels allemands et français, qui ont la responsabilité de 1 500 milliards d'euros de chiffre d'affaires et de cinq millions de salariés dans <a class="lien_interne rub" href="http://www.lemonde.fr/le-monde/" title="Toute l’actualité le monde">le monde</a> entier, nous nous soucions de l'<a target='_blank' onclick='return false;' class='lien_interne conjug' href='http://conjugaison.lemonde.fr/conjugaison/troisieme-groupe/avenir/' title='Conjugaison du verbe avenir'>avenir</a> de l'euro et de l'union économique et monétaire européenne. L'<a class="lien_interne rub" href="http://www.lemonde.fr/histoire/" title="Toute l’actualité histoire">histoire</a> de l'euro est une véritable réussite. Qui aurait pensé, lorsque l'euro a été introduit il y a douze ans, qu'il aurait aujourd'hui gagné en valeur par rapport au dollar et de nombreuses autres monnaies ?</p><div id="dfp-inread" class="dfp_slot" data-format="inread" style="display:none;"></div>
+<p>L'euro s'est imposé comme seconde monnaie de référence à côté du dollar et a renforcé le rôle de l'<a class="lien_interne rub" href="http://www.lemonde.fr/europe/" title="Toute l’actualité Europe">Europe</a> en tant que puissance économique. Avec l'euro, un marché commun doté d'une monnaie unique et sans fluctuation de cours de change a vu le jour, créant ainsi prospérité et richesse pour nous tous. Depuis son introduction, près de 9 millions de nouveaux emplois ont été créés dans la zone euro. Les <a class="lien_interne rub" href="http://www.lemonde.fr/entreprises/" title="Toute l’actualité entreprises">entreprises</a> européennes profitent de ce <a class="lien_interne rub" href="http://www.lemonde.fr/developpement/" title="Toute l’actualité développement">développement</a>. Elles ont élargi leurs capacités de financement et augmenté leur compétitivité à l'<a class="lien_interne rub" href="http://www.lemonde.fr/international/" title="Toute l’actualité international">international</a>.</p>
+<p>Le ralentissement de l'économie mondiale a conduit certains pays de l'union monétaire à s'<a target='_blank' onclick='return false;' class='lien_interne conjug' href='http://conjugaison.lemonde.fr/conjugaison/premier-groupe/endetter/' title='Conjugaison du verbe endetter'>endetter</a> encore davantage. A court terme, ces pays doivent <a target='_blank' onclick='return false;' class='lien_interne conjug' href='http://conjugaison.lemonde.fr/conjugaison/auxiliaire/%C3%AAtre/' title='Conjugaison du verbe être'>être</a> aidés pour <a target='_blank' onclick='return false;' class='lien_interne conjug' href='http://conjugaison.lemonde.fr/conjugaison/premier-groupe/regagner/' title='Conjugaison du verbe regagner'>regagner</a> leur indépendance financière et <a target='_blank' onclick='return false;' class='lien_interne conjug' href='http://conjugaison.lemonde.fr/conjugaison/premier-groupe/recr%C3%A9er/' title='Conjugaison du verbe recréer'>recréer</a> les conditions d'un avenir meilleur pour leur <a class="lien_interne rub" href="http://www.lemonde.fr/demographie/" title="Toute l’actualité population">population</a>.</p>
+<p>En contrepartie, des mesures efficaces doivent être mises en oeuvre. Le retour à une situation financière stable coûtera de nombreux milliards d'euros, mais l'<a class="lien_interne rub" href="http://www.lemonde.fr/union-europeenne/" title="Toute l’actualité Union européenne">Union européenne</a> et notre monnaie commune en valent la peine. Nous devons <a target='_blank' onclick='return false;' class='lien_interne conjug' href='http://conjugaison.lemonde.fr/conjugaison/troisieme-groupe/convaincre/' title='Conjugaison du verbe convaincre'>convaincre</a> nos concitoyens de cela.</p>
+<p><strong>RÈGLES PLUS STRICTES</strong></p>
+<p>Nous avons besoin d'une <a class="lien_interne rub" href="http://www.lemonde.fr/politique/" title="Toute l’actualité politique">politique</a> économique européenne et de règles de stabilité plus strictes. Pour <a target='_blank' onclick='return false;' class='lien_interne conjug' href='http://conjugaison.lemonde.fr/conjugaison/premier-groupe/%C3%A9viter/' title='Conjugaison du verbe éviter'>éviter</a>, à l'avenir, une crise telle que celle que nous traversons actuellement, nous devons <a target='_blank' onclick='return false;' class='lien_interne conjug' href='http://conjugaison.lemonde.fr/conjugaison/premier-groupe/renforcer/' title='Conjugaison du verbe renforcer'>renforcer</a> les règles de stabilité existantes et <a target='_blank' onclick='return false;' class='lien_interne conjug' href='http://conjugaison.lemonde.fr/conjugaison/premier-groupe/assurer/' title='Conjugaison du verbe assurer'>assurer</a> leur respect. Les solutions envisagées, comme, par exemple, l'<a class="lien_interne rub" href="http://www.lemonde.fr/exclusion/" title="Toute l’actualité exclusion">exclusion</a> de pays membres de la zone euro ou la scission entre une Union des pays du Nord et du Sud, ne sont pas bonnes. Cela aurait des conséquences qui sont difficilement prévisibles aujourd'hui. De telles propositions démagogiques ne sont pas adaptées à la gravité de la situation.</p>
+<p>Cependant, des mesures doivent être prises à temps et être aussi efficaces que possible. De plus, les Etats membres doivent <a target='_blank' onclick='return false;' class='lien_interne conjug' href='http://conjugaison.lemonde.fr/conjugaison/premier-groupe/coordonner/' title='Conjugaison du verbe coordonner'>coordonner</a>, plus étroitement qu'auparavant, leur <a class="lien_interne rub" href="http://www.lemonde.fr/afrique-politique/" title="Toute l’actualité politique">politique</a> économique intérieure et <a target='_blank' onclick='return false;' class='lien_interne conjug' href='http://conjugaison.lemonde.fr/conjugaison/premier-groupe/parler/' title='Conjugaison du verbe parler'>parler</a> d'une seule voix vis-à-vis de l'extérieur.</p>
+<p>En tant qu'industriels allemands et français, nous voulons <a target='_blank' onclick='return false;' class='lien_interne conjug' href='http://conjugaison.lemonde.fr/conjugaison/premier-groupe/souligner/' title='Conjugaison du verbe souligner'>souligner</a> les immenses avantages que l'espace monétaire commun a apportés. Nous envoyons un message de soutien aux responsables politiques, afin qu'ils mettent en place des conditions nécessaires à un euro durablement stable et compétitif. C'est la base de la future prospérité en Europe. L'union monétaire a durablement besoin de <a class="lien_interne rub" href="http://www.lemonde.fr/finance/" title="Toute l’actualité finances">finances</a> publiques solides, de règles de responsabilité claires, de structures transparentes et de conditions de concurrence équitables.</p>
+<p>Ce n'est qu'à ces conditions que l'euro sortira renforcé de la crise de la dette. Il n'y a pas d'alternative sérieuse à l'euro commun. L'euro symbolise l'Europe d'aujourd'hui. Un échec de l'euro serait un revers fatal pour l'Europe.</p>
+<hr />
+Appel Frank (Deutsche Post) ; Aschenbroich Jacques (Valeo) ; Berger Roland (Roland Berger Strategy Consultants) ; Bock Kurt (BASF) ; Bories Christel (Constellium) ; Borsig Clemens (Deutsche Bank) ; Brunck Robert (CGG Veritas) ; Buffet Patrick (Eramet) ; Burda Hubert (Hubert Burda Media Holding) ; Caparros Alain (Rewe group) ; Clamadieu Jean-Pierre (Rhodia) ; Cromme Gerhard (ThyssenKrupp) ; Crouzet Philippe (Vallourec) ; de Chalendar Pierre-André (Saint-Gobain) ; de Margerie Christophe (Total) ; de Romanet Augustin (Caisse des dépôts et consignations) ; Degenhart Elmar (Continental) ; Diekmann Michael (Allianz) ; Engel Klaus (Evonik Industries) ; Fehrenbach Franz (Robert Bosch) ; Frérot Antoine (Veolia <a class="lien_interne rub" href="http://www.lemonde.fr/environnement/" title="Toute l’actualité Environnement">Environnement</a>) ; Hagemann Snabe Jim (SAP) ; Henrot François (Groupe Rothschild & Cie Banque) ; Hermelin Paul (Cap Gemini) ; Kormann Hermut (Lazard) ; Kron Patrick (Alstom) ; Lachmann Henri (Schneider Electric) ; Lafont Bruno (Lafarge) ; Lauvergeon Anne (Areva) ; Lévy Maurice (Publicis Groupe SA) ; Lévy Jean-Bernard (Vivendi) ; Löscher Peter (Siemens) ; Mestrallet Gérard (GDF Suez) ; Obermann René (Deutsche Telekom) ;Oetker Arend (Dr Arend Oetker Holding) ; Oudéa Frédéric (Société Générale) ; Potier Benoit (Air Liquide) ; Ranque Denis (Cercle de l'<a class="lien_interne rub" href="http://www.lemonde.fr/industrie/" title="Toute l’actualité industrie">industrie</a>/Technicolor) ; Reithofer Norbert (BMW) ; Reitzle Wolfgang (Linde) ; Richard Stéphane (France Telecom) ; Rollier Michel (Michelin) ; Rose Frédéric (Technicolor) ; Schnepp Gilles (Legrand) ; Spinetta Jean-Cyril (Air-<a class="lien_interne rub" href="http://www.lemonde.fr/europeennes-france/" title="Toute l’actualité France">France</a> KLM)  ; Teyssen Johannes (E.ON)  ; Thumann Jürgen (BusinessEurope) ; Verwaayen Ben (Alcatel-Lucent) ; Viehbacher Chris (Sanofi) ; Zetsche Dieter (Daimler).<br />
+                        </div>
+
+                            <div class="mgb16">
+                            
+                            </div>
+
+                        
+
+                        
+
+                    </article>
+
+
+
+                    
+
+                        <div id="dfp-partenaire_middle" class="dfp_slot" data-format="partenaire_middle"></div>
+                        <div id="dfp-partenaire_bottom" class="dfp_slot" data-format="partenaire_bottom"></div>
+
+
+                                        <div class="toolbar"></div>
+
+                    
+
+                </div>
+
+            </div>
+            <div class="clearfix">
+                <div class="grid_10 alpha prefix_1 suffix_1 col_gauche">
+                                        <div class="reco_cross_site_outbrain">
+   <div class="OUTBRAIN" data-src="http://www.lemonde.fr/idees/article/2011/06/20/la-crise-europeenne-est-une-crise-de-la-dette-pas-de-l-euro_1538337_3232.html" data-widget-id="AR_17" data-ob-template="lemonde"></div>
+</div>
+
+                    
+
+
+  <aside class="bloc_base meme_sujet">
+
+    <span class="entete txt6">
+        Sur le même sujet    </span>
+
+    <div class="contenu">
+        <ul class="liste_chevron">
+            <li>
+                <a href="/idees/article/2017/11/22/universites-le-defi-de-la-rentree-2018_5218630_3232.html" onclick="return xt_click(this,'C','','Liens_bloc_meme_sujet::Gratuit::Gratuit','N')">
+                    Universit&eacute;s&nbsp;: le d&eacute;fi de la rentr&eacute;e 2018   
+
+                </a>
+            </li>
+            <li>
+                <a href="/idees/article/2017/11/11/sans-accord-entre-la-france-et-l-allemagne-il-n-y-aura-pas-d-avancee-en-europe_5213580_3232.html" onclick="return xt_click(this,'C','','Liens_bloc_meme_sujet::Gratuit::Gratuit','N')">
+                    &laquo;&nbsp;Sans accord entre la France et l&rsquo;Allemagne, il n&rsquo;y aura pas d&rsquo;avanc&eacute;e en Europe&nbsp;&raquo;   
+
+                </a>
+            </li>
+            <li>
+                <a href="/idees/article/2017/11/11/laurence-parisot-monsieur-hulot-abolissez-la-chasse-a-courre_5213493_3232.html" onclick="return xt_click(this,'C','','Liens_bloc_meme_sujet::Gratuit::Gratuit','N')">
+                    Laurence Parisot&nbsp;: &laquo;&nbsp;Monsieur Hulot, abolissez la chasse &agrave; courre&nbsp;!&nbsp;&raquo;   
+
+                </a>
+            </li>
+        </ul>
+    </div>
+
+        <span class="entete_exclu_abonnes">
+        <em class="txt_img">Édition abonnés Contenu exclusif</em>
+    </span>
+    <div class="contenu">
+        <ul class="liste_chevron">
+            <li>
+                <a href="/idees/article/2017/02/21/presidentielle-la-semaine-de-verite_5082714_3232.html" onclick="return xt_click(this,'C','','Liens_bloc_meme_sujet::Abonn&eacute;s::Gratuit','N')">
+                    Pr&eacute;sidentielle&nbsp;: la semaine de v&eacute;rit&eacute;&nbsp;?   
+
+                </a>
+            </li>
+            <li>
+                <a href="/idees/article/2017/12/04/laurent-wauquiez-est-ideologiquement-un-conservateur_5224089_3232.html" onclick="return xt_click(this,'C','','Liens_bloc_meme_sujet::Abonn&eacute;s::Gratuit','N')">
+                    &laquo;&nbsp;Laurent Wauquiez est id&eacute;ologiquement un conservateur&nbsp;&raquo;   
+
+                </a>
+            </li>
+            <li>
+                <a href="/idees/article/2017/12/02/aucune-subvention-publique-ne-devrait-etre-accordee-pour-des-films-finances-par-l-industrie-du-tabac_5223495_3232.html" onclick="return xt_click(this,'C','','Liens_bloc_meme_sujet::Abonn&eacute;s::Gratuit','N')">
+                    &laquo;&nbsp;Aucune subvention publique ne devrait &ecirc;tre accord&eacute;e pour des films financ&eacute;s par l&rsquo;industrie du tabac&nbsp;&raquo;   
+
+                </a>
+            </li>
+        </ul>
+    </div>
+
+    <p class="bt">
+<span class="btn_abo obf" onclick="return xt_click(this, 'C', lmd.context.page.xiti.xtn2, 'Clic_Abonnement','N');" data-href="L2Fiby8/YW1wO2NsZWY9QkxPQ0FCT0FSVEJBUzE0" title="Abonnez-vous au Monde à partir de 1 €">Abonnez-vous à partir de 1 €</span>    </p>
+
+</aside>
+
+<div id="ultimedia_wrapper" class="mgb32"></div>
+
+<script type="text/javascript">
+
+if (lmd.conf.fsw.digiteka) {
+                            var ULTIMEDIA_mdtk = "01637594";
+
+                                    var ULTIMEDIA_date = "20110622";
+                var ULTIMEDIA_target = "ultimedia_wrapper";
+    (function (d) {
+        var s = document.createElement('script');
+        s.src=('https:' == document.location.protocol ? 'https://secure' :'http://www') + '.ultimedia.com/js/common/smart.js';
+        s.setAttribute('async', true);
+        d.head.appendChild(s);
+    }(document))
+}
+
+</script>
+<div id="liste_reactions"><div id="aj-783738" data-aj-uri="/ajah/5m/lemonde/www/Controller_Module_Reaction_Element/actionAfficherPreview/WzE/1Mz/gzM/zcsNV0-/?key=fe7161a26c074de6f9ccb92b94cd0fb80ee53a31"></div><script>require(["jquery", "lib/jquery/plugin/jquery.ajah"],function($){$("#aj-783738").ajah({ url: "/ajah/5m/lemonde/www/Controller_Module_Reaction_Element/actionAfficherPreview/WzE/1Mz/gzM/zcsNV0-/?key=fe7161a26c074de6f9ccb92b94cd0fb80ee53a31" })});</script></div>
+
+<div class="rubriques_liees">
+      <a href="/idees-chroniques/">Chroniques</a> &#9642;      <a href="/chats/">Chats</a> &#9642;      <a href="/observatoires/">Observatoires</a> &#9642;      <a href="/les-amphis-du-monde/">Les Amphis du Monde</a> &#9642;      <a href="/editoriaux/">Editoriaux</a> &#9642;      <a href="/idees-livres/">Livres</a> &#9642;      <a href="/idees-enqu&ecirc;tes/">Enqu&ecirc;tes</a> &#9642;      <a href="/controverses/">Controverses</a> &#9642;      <a href="/idees-rencontres/">Rencontres</a> &#9642;      <a href="/idees-tribunes/">Tribunes</a> </div>
+
+
+                </div>
+            </div>
+        </div>
+        <div class="grid_6 omega col_droite">
+            
+            
+
+   <div id="aj-988312" data-aj-uri="/ajah/5m/lemonde/web/Controller_Module_Colonne_Multimedia/actionMultimediaBloc/WzM/yMz/IsZ/mFsc2Vd/?key=0348c2c3fa2905e020d2ce5605a6629102daeb1b"></div><script>require(["jquery", "lib/jquery/plugin/jquery.ajah"],function($){$("#aj-988312").ajah({ url: "/ajah/5m/lemonde/web/Controller_Module_Colonne_Multimedia/actionMultimediaBloc/WzM/yMz/IsZ/mFsc2Vd/?key=0348c2c3fa2905e020d2ce5605a6629102daeb1b" })});</script>
+
+<div id="dfp-pave_haut" class="dfp_slot" data-format="pave_haut"></div>
+
+
+
+
+   <div id="aj-c65b1e" data-aj-uri="/ajah/5m/lemonde/www/Controller_Module_Social_Pluspartages/actionAfficher/W3R/ydW/Vd/EMPTY/?key=e9c1df2637b3a3d3a2ba3035fdd06a727446de91"></div><script>require(["jquery", "lib/jquery/plugin/jquery.ajah"],function($){$("#aj-c65b1e").ajah({ url: "/ajah/5m/lemonde/www/Controller_Module_Social_Pluspartages/actionAfficher/W3R/ydW/Vd/EMPTY/?key=e9c1df2637b3a3d3a2ba3035fdd06a727446de91" })});</script>
+
+   <div id="aj-0f6eee" data-aj-uri="/ajah/5m/lemonde/www/Controller_Module_Pave_Edito_Item/actionAfficherPave/W25/1bG/wse/yJydWJyaXF1ZV9pZCI6MzIzMn0sNTIzNTU1NCxudWxsXQ--/?key=b6377700d4d24fddd834097708545b8cecf7676f"></div><script>require(["jquery", "lib/jquery/plugin/jquery.ajah"],function($){$("#aj-0f6eee").ajah({ url: "/ajah/5m/lemonde/www/Controller_Module_Pave_Edito_Item/actionAfficherPave/W25/1bG/wse/yJydWJyaXF1ZV9pZCI6MzIzMn0sNTIzNTU1NCxudWxsXQ--/?key=b6377700d4d24fddd834097708545b8cecf7676f" })});</script>
+
+    <div id="dfp-pave_milieu" class="dfp_slot" data-format="pave_milieu"></div>
+
+<div id="aj-0c1038" data-aj-uri="/ajah/5m/lemonde/www/Controller_Module_Abonnes_AppelJelec/actionAfficher/W3R/ydW/UsI/kJMT0NBQk9BUlRDT0xEUjE0IiwiIixudWxsLDUzXQ--/?key=f98aa4214aa7405eaf019bedb7936d35af6dd5fc"></div><script>require(["jquery", "lib/jquery/plugin/jquery.ajah"],function($){$("#aj-0c1038").ajah({ url: "/ajah/5m/lemonde/www/Controller_Module_Abonnes_AppelJelec/actionAfficher/W3R/ydW/UsI/kJMT0NBQk9BUlRDT0xEUjE0IiwiIixudWxsLDUzXQ--/?key=f98aa4214aa7405eaf019bedb7936d35af6dd5fc" })});</script>
+
+  <div class="block_elementum outbrain">
+        <div class="OUTBRAIN" data-src="http://www.lemonde.fr/idees/article/2011/06/20/la-crise-europeenne-est-une-crise-de-la-dette-pas-de-l-euro_1538337_3232.html" data-widget-id="SB_2" data-ob-template="lemonde"></div>
+    <div class="OUTBRAIN" data-src="http://www.lemonde.fr/idees/article/2011/06/20/la-crise-europeenne-est-une-crise-de-la-dette-pas-de-l-euro_1538337_3232.html" data-widget-id="SB_3" data-ob-template="lemonde"></div>
+</div>
+
+
+
+<div id="aj-a628e8" data-aj-uri="/ajah/5m/lemonde/www/Controller_Module_Widget_Bizdev/actionAfficher/WzM/yMz/IsI/npvbmVfY29sb25uZV9iaXpkZXZfZWx0MSIsMSxmYWxzZSwzMjMyXQ--/?key=a3a11feced8268c89bf5d8cd1b020a4bd4ab89fe"></div><script>require(["jquery", "lib/jquery/plugin/jquery.ajah"],function($){$("#aj-a628e8").ajah({ url: "/ajah/5m/lemonde/www/Controller_Module_Widget_Bizdev/actionAfficher/WzM/yMz/IsI/npvbmVfY29sb25uZV9iaXpkZXZfZWx0MSIsMSxmYWxzZSwzMjMyXQ--/?key=a3a11feced8268c89bf5d8cd1b020a4bd4ab89fe" })});</script>
+
+    <div id="dfp-pave_bas" class="dfp_slot" data-format="pave_bas"></div>
+
+<div id="aj-d3c445" data-aj-uri="/ajah/5m/lemonde/www/Controller_Module_Widget_Bizdev/actionAfficher/WzM/yMz/IsI/npvbmVfY29sb25uZV9iaXpkZXZfZWx0MiIsMSxmYWxzZSwzMjMyXQ--/?key=a30adc006acc9e6cf06c12ef7e195740340cbbe8"></div><script>require(["jquery", "lib/jquery/plugin/jquery.ajah"],function($){$("#aj-d3c445").ajah({ url: "/ajah/5m/lemonde/www/Controller_Module_Widget_Bizdev/actionAfficher/WzM/yMz/IsI/npvbmVfY29sb25uZV9iaXpkZXZfZWx0MiIsMSxmYWxzZSwzMjMyXQ--/?key=a30adc006acc9e6cf06c12ef7e195740340cbbe8" })});</script>
+
+        </div>
+
+    </div>
+    <!-- #WALL -->
+
+</div>
+<!-- #TOASTER -->
+<script>
+    require(["lmd/module/element/bootstrap"], function (bootstrap) {
+        var params = {};
+        params.toolbar = {};
+        params.toolbar.envoyer = {link: "http://www.lemonde.fr/envoyer-par-email/article/2011/06/20/1538337.html"};
+        params.toolbar.imprimer = {active: true};
+
+        bootstrap.init(params);
+    });
+
+    require(['lmd/ui/iframe-fit-content'], function (iframeFitContent) {
+        iframeFitContent.init('articleBody', 'js_multimedia_embed');
+    });
+</script>
+
+<script>
+    if (lmd.conf.fsw.tym) {
+        require(['jquery', 'lmd/module/video/tym-script'], function ($, tymScript) {
+            $('#articleBody .tym').each(function () {
+                tymScript($(this).data('tym-playerid'));
+            });
+        });
+    }
+</script>
+
+<div class="OUTBRAIN" data-src="http://www.lemonde.fr/idees/article/2011/06/20/la-crise-europeenne-est-une-crise-de-la-dette-pas-de-l-euro_1538337_3232.html" data-widget-id="TR_1" data-ob-template="lemonde" style="display:none"></div>
+<script>
+require(['lmd/core/ux/outbrain'], function (ob) { ob.load(); });
+</script>
+
+
+
+        <div id="dfp-banniere_basse" class="dfp_slot" data-format="banniere_basse"></div>
+
+    <div id="aj-2e9edd" data-aj-uri="/ajah/5m/lemonde/web/Controller_Module_Deroule_Bloc_Paves/actionAfficherBizdevOffre/WzM/yMz/Isd/HJ1ZV0-/?key=533899a2b4be32596555f4c1c309065cf0e988be"></div><script>require(["jquery", "lib/jquery/plugin/jquery.ajah"],function($){$("#aj-2e9edd").ajah({ url: "/ajah/5m/lemonde/web/Controller_Module_Deroule_Bloc_Paves/actionAfficherBizdevOffre/WzM/yMz/Isd/HJ1ZV0-/?key=533899a2b4be32596555f4c1c309065cf0e988be" })});</script>
+    <div id="aj-704004" data-aj-uri="/ajah/5m/lemonde/www/Controller_Module_General_Footer_Serviciel/actionAfficher/WyJ/SVU/JSS/VFVRV9TRVJWSUNFUyJd/?key=48ef2c0f4847cd071d1f0a44fc735c67dafe3a50"></div><script>require(["jquery", "lib/jquery/plugin/jquery.ajah"],function($){$("#aj-704004").ajah({ url: "/ajah/5m/lemonde/www/Controller_Module_General_Footer_Serviciel/actionAfficher/WyJ/SVU/JSS/VFVRV9TRVJWSUNFUyJd/?key=48ef2c0f4847cd071d1f0a44fc735c67dafe3a50" })});</script>
+    <div id="footer">
+    <div class="footer_gratuit txt3">
+<a class="zone_abo" rel="nofollow" href="https://abo.lemonde.fr#xtor=CS1-263[BOUTONS_LMFR]-[FOOTER]-53-[Article]" onclick="return xt_click(this, 'C', '', 'Abo::Footer', 'N')">
+            <div class="abonnement">
+                <p class="contenu">
+                <span>Le monde abonnements</span>
+                Profitez du journal où et quand vous voulez. Abonnements papier, offres 100 % numériques sur Web et tablette.
+                </p>
+                <p class="bt">
+                <span class="btn">S'abonner au Monde à partir de 1 €</span>
+                </p>
+            </div>
+<img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" width="350" height="155" alt=" " data-src="//s1.lemde.fr/medias/web/1.2.705/img/elements_lm/footer_supports.png" data-lazyload="true" onload="lmd.pic(this);" onerror="lmd.pic(this);" class="lazy-retina"></a>
+        <div class="deja_abonne">
+            <div>
+                <span class="accroche">Déjà abonné au<br>journal <em>Le Monde</em> ?</span>
+                <ul>
+                    <li>
+                        <a href="https://www.lemonde.fr/sfuser/account" target="_blank" rel="nofollow">
+                            Activez votre accès à l'Édition abonnés du Monde.fr
+                        </a>
+                    </li>
+                    <li>
+                        <a href="https://moncompte.lemonde.fr/" target="_blank" rel="nofollow">
+                            Gérez votre abonnement
+                        </a>
+                    </li>
+                </ul>
+            </div>
+<img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" width="123" height="78" alt=" " data-src="//s1.lemde.fr/medias/web/1.2.705/img/elements_lm/footer_journaux.png" data-lazyload="true" onload="lmd.pic(this);" onerror="lmd.pic(this);" class="lazy-retina">        </div>
+    </div>
+</div>
+
+<footer id="footer-page" class="univers-sombre">
+    <section>
+        <div>
+            <strong class="titre3" data-toggle="context">Les rubriques du Monde.fr</strong>
+            <ul>
+                <li><a href="/international/" title="International" target="_self">International</a></li>
+                <li><a href="/politique/" title="Politique" target="_self">Politique</a></li>
+                <li><a href="/societe/" title="Soci&eacute;t&eacute;" target="_self">Soci&eacute;t&eacute;</a></li>
+                <li><a href="/economie/" title="&Eacute;conomie" target="_self">&Eacute;conomie</a></li>
+                <li><a href="/culture/" title="Culture" target="_self">Culture</a></li>
+                <li><a href="/sport/" title="Sport" target="_self">Sport</a></li>
+                <li><a href="/pixels/" title="Techno" target="_self">Techno</a></li>
+                <li><a href="/m-styles/" title="Style" target="_self">Style</a></li>
+                <li><a href="/m-perso/" title="L'&eacute;poque" target="_self">L'&eacute;poque</a></li>
+                <li><a href="/idees/" title="Id&eacute;es" target="_self">Id&eacute;es</a></li>
+                <li><a href="/planete/" title="Plan&egrave;te" target="_self">Plan&egrave;te</a></li>
+                <li><a href="/education/" title="&Eacute;ducation" target="_self">&Eacute;ducation</a></li>
+                <li><a href="/disparitions/" title="Disparitions" target="_self">Disparitions</a></li>
+                <li><a href="/sante/" title="Sant&eacute;" target="_self">Sant&eacute;</a></li>
+                <li><a href="/monde-academie/" title="Monde Acad&eacute;mie" target="_self">Monde Acad&eacute;mie</a></li>
+                <li><a href="/data/france/legislatives-2017/" title="R&eacute;sultats &eacute;lection l&eacute;gislatives 2017" target="_self">R&eacute;sultats &eacute;lection l&eacute;gislatives 2017</a></li>
+                <li><a href="/data/resultats-circonscriptions/legislatives-2017/" title="R&eacute;sultats par circonscription" target="_self">R&eacute;sultats par circonscription</a></li>
+                <li><a href="http://www.lemonde.fr/data/resultats-communes/legislatives-2017/" title="R&eacute;sultats par commune" target="_self">R&eacute;sultats par commune</a></li>
+            </ul>
+        </div>
+        <div>
+            <strong class="titre3" data-toggle="context">Les services du Monde</strong>
+            <ul>
+                <li><a href="http://voiture-occasion.lemonde.fr" title="Annonces auto" target="_self">Annonces auto</a></li>
+                <li><a href="http://immobilier.lemonde.fr/" title="Annonces immo" target="_self">Annonces immo</a></li>
+                <li><a href="http://conjugaison.lemonde.fr" title="Conjugaison" target="_self">Conjugaison</a></li>
+                <li><a href="http://anglais.lemonde.fr" title="Cours d'anglais" target="_self">Cours d'anglais</a></li>
+                <li><a href="/jeux/" title="Jeux" target="_self">Jeux</a></li>
+                <li><a href="https://formation-professionnelle.lemonde.fr/" title="Formation professionnelle" target="_self">Formation professionnelle</a></li>
+                <li><a href="http://boutique.lemonde.fr/#xtor=AD-9" title="La boutique du Monde" target="_blank">La boutique du Monde</a></li>
+                <li><a href="http://prix-immobilier.lemonde.fr/prix-immobilier/" title="Prix de l'immobilier" target="_self">Prix de l'immobilier</a></li>
+                <li><a href="/programme-tele/" title="Programme t&eacute;l&eacute;" target="_self">Programme t&eacute;l&eacute;</a></li>
+                <li><a href="http://shopping.lemonde.fr" title="Shopping" target="_self">Shopping</a></li>
+                <li><a href="https://www.sourcesure.eu/" title="Source S&ucirc;re" target="_blank">Source S&ucirc;re</a></li>
+                <li><a href="/pratique/trafic-idf.html" title="Trafic" target="_self">Trafic</a></li>
+                <li><a href="http://www.lemonde.fr/verification/" title="Decodex" target="_self">Decodex</a></li>
+                <li><a href="http://progresser-orthographe.lemonde.fr/" title="Orthographe et grammaire" target="_self">Orthographe et grammaire</a></li>
+            </ul>
+        </div>
+        <div>
+            <strong class="titre3" data-toggle="context">Sur le web</strong>
+            <ul>
+                <li><a href="http://sortir.telerama.fr/paris/concerts.php" title="Concerts &agrave; Paris" target="_self">Concerts &agrave; Paris</a></li>
+                <li><a href="http://www.telerama.fr/livres/livre_prefredaction.php" title="S&eacute;lection de livres" target="_self">S&eacute;lection de livres</a></li>
+                <li><a href="http://television.telerama.fr/tele/grille.php" title="Programme TNT" target="_self">Programme TNT</a></li>
+                <li><a href="http://sortir.telerama.fr/paris/boutiques.php" title="Boutiques &agrave; Paris" target="_self">Boutiques &agrave; Paris</a></li>
+                <li><a href="http://television.telerama.fr/tele/chaine-tv/arte,111.php" title="Programme TV de Arte en replay" target="_self">Programme TV de Arte en replay</a></li>
+                                <li><a href="http://sortir.telerama.fr/paris/spectacles.php" title="Spectacles &agrave; Paris" target="_self">Spectacles &agrave; Paris</a></li>
+                <li><a href="http://television.telerama.fr/tele/grille.php" title="Le programme t&eacute;l&eacute;vision" target="_self">Le programme t&eacute;l&eacute;vision</a></li>
+                <li><a href="http://www.telerama.fr/festivals-ete/" title="Festivals d'&eacute;t&eacute;" target="_self">Festivals d'&eacute;t&eacute;</a></li>
+                <li><a href="http://www.telerama.fr/cine/film_genre.php" title="Films au cin&eacute;ma" target="_self">Films au cin&eacute;ma</a></li>
+                <li><a href="http://www.telerama.fr/cine/tous-les-films_genre.php" title="Tous les films" target="_self">Tous les films</a></li>
+            </ul>
+        </div>
+        <div>
+            <strong class="titre3" data-toggle="context">Les sites du Groupe</strong>
+            <ul>
+                <li><a href="/service/qui_sommes_nous_telerama.html" title="T&eacute;l&eacute;rama.fr" target="_self">T&eacute;l&eacute;rama.fr</a></li>
+                <li><a href="/service/qui_sommes_nous_talents.html" title="Talents.fr" target="_self">Talents.fr</a></li>
+                <li><a href="http://www.huffingtonpost.fr/" title="Le Huffington Post" target="_blank">Le Huffington Post</a></li>
+                <li><a href="http://www.courrierinternational.com/" title="CourrierInternational.com" target="_blank">CourrierInternational.com</a></li>
+                <li><a href="http://www.monde-diplomatique.fr/" title="Monde-Diplomatique.fr" target="_blank">Monde-Diplomatique.fr</a></li>
+                <li><a href="http://www.sdllemonde.fr/" title="La Soci&eacute;t&eacute; des lecteurs du Monde" target="_blank">La Soci&eacute;t&eacute; des lecteurs du Monde</a></li>
+                <li><a href="/kiosque/recherche/" title="Le Prix Le Monde de la recherche" target="_blank">Le Prix Le Monde de la recherche</a></li>
+                <li><a href="https://tempsreel.nouvelobs.com/" title="L'Obs" target="_blank">L'Obs</a></li>
+            </ul>
+        </div>
+        <div class="liste-liens-data">
+            <strong class="titre3" data-toggle="context">Partenaires Le Monde</strong>
+            <ul class="liste-plate">
+                <li><a href="http://dicocitations.lemonde.fr/proverbes-france.php" title="proverbe fran&ccedil;ais" target="_self">proverbe fran&ccedil;ais</a></li>
+                                <li><a href="https://jardinage.lemonde.fr/dossier-232-hortensia-hydrangea.html" title="hortensia" target="_self">hortensia</a></li>
+                <li><a href="" title="" target="_self"></a></li>
+                <li><a href="http://chefsimon.lemonde.fr/recettes/pate-feuilletee-a-6-tours" title="Pate feuillet&eacute;e" target="_self">Pate feuillet&eacute;e</a></li>
+                <li><a href="http://chefsimon.lemonde.fr/recettes/riz-pilaf--4" title="Riz pilaf" target="_self">Riz pilaf</a></li>
+                <li><a href="http://chefsimon.lemonde.fr/recettes/financiers--14" title="Recette financier" target="_self">Recette financier</a></li>
+                                <li><a href="http://modele-lettre.lemonde.fr/lettre-1133/lettre-de-attestation-de-mutation.html" title="attestation de mutation" target="_self">attestation de mutation</a></li>
+                                <li><a href="https://formation-professionnelle.lemonde.fr/recherche/formation-professionnelle-comptabilite" title="Formation comptabilit&eacute;" target="_self">Formation comptabilit&eacute;</a></li>
+                                <li><a href="http://codepromo.lemonde.fr" title="Codes promo" target="_self">Codes promo</a></li>
+                <li><a href="http://codepromo.lemonde.fr" title="Codes promo" target="_self">Codes promo</a></li>
+                                <li><a href="http://paroles2chansons.lemonde.fr/paroles-camila-cabello/paroles-havana.html" title="Paroles et traduction Havana" target="_self">Paroles et traduction Havana</a></li>
+            </ul>
+        </div>
+    </section>
+    <section>
+        <div class="liste-plate">
+            <strong>Suivez-nous</strong>
+            <a href="http://www.facebook.com/lemonde.fr" title="Suivez-nous sur Facebook" class="svg-facebook" target="_blank">Suivez-nous sur Facebook</a>
+            <a href="http://twitter.com/lemondefr" title="Suivez-nous sur Twitter" class="svg-twitter" target="_blank">Suivez-nous sur Twitter</a>
+            <a href="https://plus.google.com/+LeMondefr" title="Suivez-nous sur Google Plus" class="svg-google" target="_blank">Suivez-nous sur Google Plus</a>
+            <a href="https://www.instagram.com/lemondefr/" title="Instagram" target="_blank" class="svg-instagram">Suivez-nous sur Instagram</a>
+            <a href="/mobile/" title="Suivez-nous sur Mobile" class="svg-mobile">Suivez-nous sur Mobile</a>
+            <a href="/rss/" title="Abonnez-nous à nos flux RSS" class="svg-rss">Abonnez-nous à nos flux RSS</a>
+        </div>
+        <div class="liste-plate">
+            <a href="https://secure.lemonde.fr/sfuser/newsletters" title="Recevez nos newsletters" target="_self" class="lien-newsletter">Recevez nos newsletters</a>
+        </div>
+        <div class="liste-plate">
+            <strong>Index actualités</strong>
+            <a href="/index-rubriques/A/" title="A" target="_self">A</a>
+            <a href="/index-rubriques/B/" title="B" target="_self">B</a>
+            <a href="/index-rubriques/C/" title="C" target="_self">C</a>
+            <a href="/index-rubriques/D/" title="D" target="_self">D</a>
+            <a href="/index-rubriques/F/" title="E" target="_self">E</a>
+            <a href="/index-rubriques/F/" title="F" target="_self">F</a>
+            <a href="/index-rubriques/G/" title="G" target="_self">G</a>
+            <a href="/index-rubriques/H/" title="H" target="_self">H</a>
+            <a href="/index-rubriques/I/" title="I" target="_self">I</a>
+            <a href="/index-rubriques/J/" title="J" target="_self">J</a>
+            <a href="/index-rubriques/K/" title="K" target="_self">K</a>
+            <a href="/index-rubriques/L/" title="L" target="_self">L</a>
+            <a href="/index-rubriques/M/" title="M" target="_self">M</a>
+            <a href="/index-rubriques/N/" title="N" target="_self">N</a>
+            <a href="/index-rubriques/O/" title="O" target="_self">O</a>
+            <a href="/index-rubriques/P/" title="P" target="_self">P</a>
+            <a href="/index-rubriques/Q/" title="Q" target="_self">Q</a>
+            <a href="/index-rubriques/R/" title="R" target="_self">R</a>
+            <a href="/index-rubriques/S/" title="S" target="_self">S</a>
+            <a href="/index-rubriques/T/" title="T" target="_self">T</a>
+            <a href="/index-rubriques/U/" title="U" target="_self">U</a>
+            <a href="/index-rubriques/V/" title="V" target="_self">V</a>
+            <a href="/index-rubriques/W/" title="W" target="_self">W</a>
+            <a href="/index-rubriques/X/" title="X" target="_self">X</a>
+            <a href="/index-rubriques/Y/" title="Y" target="_self">Y</a>
+            <a href="/index-rubriques/Z/" title="Z" target="_self">Z</a>
+        </div>
+    </section>
+    <section class="liste-plate _separateur">
+        <a href="/service/licence_et_droits_de_reproduction.html" title="© Le Monde.fr" target="_self" rel="nofollow">© Le Monde.fr</a>
+        |&nbsp;<a href="https://moncompte.lemonde.fr/cgv" title="CGV" target="_self" rel="nofollow">CGV</a>
+        |&nbsp;<a href="http://www.ojd-internet.com/chiffres" title="Fréquentation certifiée par l'OJD" target="_blank" rel="nofollow">Fréquentation certifiée par l'OJD</a>
+        |&nbsp;<a href="/service/donnees_personnelles.html" title="Données personnelles" target="_self" rel="nofollow">Données personnelles</a>
+        |&nbsp;<a href="/service/mentions_legales.html" title="Mentions légales" target="_self" rel="nofollow">Mentions légales</a>
+        |&nbsp;<a href="/service/qui_sommes_nous.html" title="Qui sommes-nous ?" target="_self" rel="nofollow">Qui sommes-nous ?</a>
+        |&nbsp;<a href="/actualite-medias/article/2010/11/03/la-charte-d-ethique-et-de-deontologie-du-groupe-le-monde_1434737_3236.html" title="Charte groupe" target="_self" rel="nofollow">Charte groupe</a>
+        |&nbsp;<a href="http://mpublicite.fr" title="Publicité" target="_blank" rel="nofollow">Publicité</a>
+        |&nbsp;<a href="http://www.lemonde.fr/faq" title="Foire aux questions" target="_blank" rel="nofollow">Aide (FAQ)</a>
+    </section>
+    <p class="texte-discret">
+        Journal d'information en ligne, Le Monde.fr offre à ses visiteurs un
+        panorama complet de l'actualité. Découvrez chaque jour toute l'info en
+        direct (de la politique à l'économie en passant par le sport et la
+        météo) sur Le Monde.fr, le site de news leader de la presse française
+        en ligne.
+    </p>
+</footer>
+
+    <div id="bandeau_bas">
+   <div class="conteneur_en_continu"><a href="/actualite-en-continu" class="tetiere">En Continu</a>
+
+</div>
+   <div class="conteneur_lives"></div>
+   <div class="conteneur_alerte invisible"></div>
+</div>
+
+<script>
+require(["jquery","lmd/module/alerte"],function(b,a){new a({$el:b("#bandeau_bas .conteneur_alerte")})});
+require(["jquery","lmd/module/encontinu"],function(b,a){new a({$el:b("#bandeau_bas .conteneur_en_continu")})});
+require(["jquery","lmd/module/lives"],function(b,a){(new a).attach("#bandeau_bas .conteneur_lives")});
+</script>
+    </div><!--/habillagepub-->
+
+    <script src="//asset.lemde.fr/data/0.17.0/js/index.min.js" async></script>
+
+    <div id="dfp-dhtml" class="dfp_slot" data-format='dhtml'></div>
+<script>require(['lmd/core/dfp']);</script>
+
+<script>require(["lmd/core/ux/widget-position"], function(a) { a.init(); });</script>
+    
+<script>
+    if (window.xtparam) {
+        window.xtparam += '&x3=';
+    } else {
+        window.xtparam = '&x3=';
+    }
+</script>
+
+<script>
+    var blockAdBlock = (function (lmd) {
+        'use strict';
+
+        var blockAdBlock;
+        var fnCallback;
+        var status;
+        // AT Internet x4 values : 1 and 2 are used in script, 3 for noscript and 4 not used here.
+        var adblockStatus = {
+            'YES': 1,
+            'NO': 2,
+            'NOSCRIPT': 3,
+            'NSP': 4
+        };
+
+        var send = function () {
+            require(['lmd/module/xiti/hit'], function (xiti) {
+                if (!xiti.has_hit('Ad_Block::Actif')) {
+                    xiti.hit(this, 'C', '0', 'Ad_Block::Actif', 'A');
+                }
+            });
+        };
+
+        var callXiti = function (adbStatus) {
+            status = adbStatus;
+            if (status === adblockStatus.YES) {
+                send();
+            }
+
+            if (fnCallback) {
+                fnCallback(status);
+            }
+        };
+
+        require(['xitistatus'], function () {
+            blockAdBlock = new BlockAdBlock({
+                checkOnLoad: false,
+                resetOnEnd: true
+            });
+
+            if (blockAdBlock === undefined) {
+                callXiti(adblockStatus.YES);
+            } else {
+                blockAdBlock.onDetected(function () {
+                    callXiti(adblockStatus.YES);
+                });
+
+                blockAdBlock.onNotDetected(function () {
+                    callXiti(adblockStatus.NO);
+                });
+
+                blockAdBlock.check();
+            }
+        }, function (err) {
+            callXiti(adblockStatus.NSP)
+        });
+
+        return {
+            getStatus: function (fn) {
+                if (status) {
+                    fn(status);
+                } else {
+                    fnCallback = fn;
+                }
+            }
+        };
+    }(lmd));
+</script>
+
+<div id="xiti-logo">
+    <script>
+        var xiti = (function (blockAdBlock) {
+            var loadAfter = function (e, fn) {
+                var rs = e.readyState;
+                if (rs && rs !== 'complete' && rs !== 'loaded') {
+                    return;
+                }
+                try {
+                    fn.apply(this);
+                } catch (ex) {
+
+                }
+            },
+
+            loadJs = function (src, onload) {
+                var a = document.createElement('script');
+                a.type = 'text/javascript';
+                a.async = false;
+                a.src = src;
+                if (typeof onload === 'function') {
+                    if (a.addEventListener) {
+                        a.addEventListener('load', function () {
+                            loadAfter(a, onload);
+                        });
+                    } else {
+                        a.attachEvent && a.attachEvent('onreadystatechange', function () {
+                            loadAfter(a, onload);
+                        });
+                    }
+                }
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0] || document.getElementsByTagName('script')[0].parentNode).insertBefore(a, null);
+            },
+
+            loadCore = function () {
+                loadJs(lmd.conf.medias.location.base_url_version + '/js/lib/xiti/4.6.4/xtcore.js', function () {
+                    require(['lmd/module/xiti/hit'], function (hit_xiti) {
+                        hit_xiti.resolve();
+                    });
+                });
+                lmd.context.page.xiti_call = true;
+            };
+
+            return {
+                type: {
+                    inscrits: 'INSCRIT'
+                },
+                init: function () {
+                    if (window.xtparam === undefined || window.xtparam === null) {
+                        window.xtparam = '';
+                    }
+
+                    blockAdBlock.getStatus(function (status) {
+                        window.xtparam += '&ac=' + window.xt_ac + '&an=' + window.xt_an + window.xt_multc + '&x4=' + status;
+                        loadJs(lmd.conf.medias.location.base_url_version + '/js/lib/xiti/4.4.007/xtclicks.js', loadCore);
+                    });
+                }
+            };
+        })(blockAdBlock);
+
+        xtnv = document;
+        xtsd = (document.location.protocol === 'http:') ? 'http://logc2' : 'https://logs13';
+        xtsite = function() {
+            var viewPortWitdh = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+            var breakpoints = lmd.context.page.xiti.xtbreakpoints || {};
+            var xtsite = lmd.context.page.xiti.xtsite;
+
+            for (var device in breakpoints) {
+                var isValidBreakpoint = true;
+
+                if (breakpoints[device]['min']) {
+                    isValidBreakpoint = viewPortWitdh >= breakpoints[device]['min'];
+                }
+
+                if (isValidBreakpoint && breakpoints[device]['max']) {
+                    isValidBreakpoint = viewPortWitdh <= breakpoints[device]['max'];
+                }
+
+                if (isValidBreakpoint) {
+                    xtsite = lmd.context.page.xiti.xtsites[device];
+                    break;
+                }
+            }
+
+            lmd.context.page.xiti.xtsite = xtsite;
+
+            return xtsite;
+        }();
+        xtn2 = lmd.context.page.xiti.xtn2; 
+        xtcustom = lmd.context.page.xiti.xtcustom; 
+        xtpage = lmd.context.page.xiti.xtpage; 
+        xtergo = lmd.context.page.xiti.xtergo ? '1' : '0'; 
+        xtdi ='';
+        window.xt_an = ''; 
+        window.xt_ac = ''; 
+
+        window.xt_multc = lmd.context.page.xiti.xt_multc;
+        if (window.xt_multc === null) {
+            window.xt_multc = '';
+        }
+
+        xt_tag = lmd.context.page.xiti.xt_tag; 
+        if (xt_tag != null) {
+            if (window.xtparam != null) {
+                window.xtparam += '&tag=' + xt_tag;
+            } else {
+                window.xtparam = '&tag=' + xt_tag;
+            }
+        }
+        var x12 = lmd.context.page.xiti.x12;
+        if (x12 != null) {
+            if (window.xtparam != null) {
+                window.xtparam += '&x12=' + x12;
+            } else {
+                window.xtparam = '&x12=' + x12;
+            }
+        }
+
+        var x5 = lmd.context.page.xiti.x5;
+        if (x5 != null) {
+            if (window.xtparam != null) {
+                window.xtparam += '&x5=' + x5;
+            } else {
+                window.xtparam = '&x5=' + x5;
+            }
+        }
+
+        var element = false;
+        var restreint = false;
+        var tdb_user_id = '';
+
+        if (typeof lmd === 'undefined' || lmd === '') {
+            xiti.init();
+        } else {
+            if (lmd.context !== undefined && lmd.context !== null && lmd.context.element !== undefined && lmd.context.element !== null && lmd.context.element.restreint !== undefined) {
+                element = true;
+                restreint = lmd.context.element.restreint;
+            }
+
+            tdb_user_id = (document.cookie.match('(^|; )tdb_user_id=([^;]*)') || 0)[2];
+            if (tdb_user_id === undefined || tdb_user_id === '') {
+                if (element) {
+                    window.xt_multc += '&x8=' + (restreint ? '24' : '13');
+                }
+                xiti.init();
+            } else {
+                require(['jquery', 'lmd/core/auth'], function ($, a) {
+                    a.loadUser().done(function () {
+                        var params;
+                        var user = a.user;
+                        if (user !== null) {
+                            if (user.id > 0) {
+                                window.xt_an = user.id;
+                            } else {
+                                window.xt_an = '';
+                            }
+
+                            if ('inscrit' === user.type) {
+                                window.xt_ac = xiti.type.inscrits;
+
+                                if (element) {
+                                    params = { 'item_id': lmd.context.element.id };
+                                    $.getJSON('/ws/1/restreint/verif_item/', params).done($.proxy(function (response) {
+                                        var achat_acte = response.url !== null && response.url.length > 0;
+                                        window.xt_multc += '&x8=' + (restreint ? (achat_acte ? '23' : '24') : '13');
+
+                                        xiti.init();
+                                    }, this));
+                                } else {
+                                    xiti.init();
+                                }
+                            }
+
+                            else if (user.type === 'abonne' && user.classe_abonnement !== null) {
+                                window.xt_ac = user.classe_abonnement;
+
+                                if (element) {
+                                    window.xt_multc += '&x8=' + (restreint ? '23' : '13');
+                                }
+
+                                xiti.init();
+                            }
+                        } else {
+                            xiti.init();
+                        }
+                    });
+                });
+            }
+        }
+    </script>
+    <object>
+        <noscript>
+            <img src="http://logc2.xiti.com/hit.xiti?s=43260&s2=53&p=idees::la_crise_europeenne_est_une_crise_de_la_dette_pas_de_l_euro&ptype=&di=&an=&ac=&x1=&x2=article&x4=3" width="1" height="1" alt="">
+        </noscript>
+    </object>
+
+    <script>
+        (function (w) {
+            var i = 0;
+            function attestScroll() {
+                i++;
+                if (w.xt_med || i > 5) {
+                    w.removeEventListener('scroll', attestScroll);
+                    typeof xt_med === 'function' && xt_med('C', '', 'Scroll', 'A');
+                }
+            }
+            w.addEventListener('scroll', attestScroll);
+        }(window));
+    </script>
+</div>
+<script>
+    if (lmd.conf.fsw.google_analytics) {
+        var _gaq = _gaq || [];
+        _gaq.push(['_setAccount', 'UA-15394037-2']);
+        _gaq.push(['_setDomainName', '.lemonde.fr']);
+        _gaq.push(['_setVisitorCookieTimeout', 86400 * 30 * 13 * 1000]); // 13 months in milliseconds
+        _gaq.push(['_trackPageview']);
+        _gaq.push(['_trackPageLoadTime']);
+        var ga_src_require = ('https:' == document.location.protocol) ? 'https://ssl' : 'http://www';
+        require([ga_src_require + '.google-analytics.com/ga.js']);
+    }
+</script>
+
+
+<script>if(lmd.conf.fsw.chartbeat){_sf_async_config={uid:12231,domain:"lemonde.fr"};lmd.onload(function(){window._sf_endpt=(new Date).getTime();require([document.location.protocol+"//static.chartbeat.com/js/chartbeat.js"])});}</script>
+
+<script>lmd.conf.fsw.ownpage && lmd.onload(function(){ require(['lmd/core/metrics/ownpage'], function(op){ op.init(); }); });</script>
+
+<script> require(['lmd/core/footer-tracking']); </script>
+
+    
+</body>
+</html>
+
+<!--Rosae 2018/01/03 17:41:11 3.30 25.90 web04:5681:5.96 httpfront-->


### PR DESCRIPTION
Hi Andres!

I catch this error:
Uncaught Error: Call to undefined method DOMEntityReference::getAttribute() in vendor/andreskrey/readability.php/src/Readability.php:528

When parse [www.lemonde.fr](http://www.lemonde.fr/idees/article/2011/06/20/la-crise-europeenne-est-une-crise-de-la-dette-pas-de-l-euro_1538337_3232.html) with config:

> $config->setWordThreshold(100)  
->setSummonCthulhu(true) 
->setFixRelativeURLs(true)  
->setOriginalURL($url);  


After some investigations seem to be caused by a missing class on the DOM's overwrite classes.

Maybe should I add DOMEntity too?
