### PR TITLE
Fix error C14N

### DIFF
--- a/src/Readability.php
+++ b/src/Readability.php
@@ -1564,7 +1564,7 @@ class Readability
      */
     public function getContent()
     {
-        return $this->content->C14N();
+        return (null !== $this->content) ? $this->content->C14N() : null;
     }
 
     /**

--- a/src/Readability.php
+++ b/src/Readability.php
@@ -1564,7 +1564,7 @@ class Readability
      */
     public function getContent()
     {
-        return (null !== $this->content) ? $this->content->C14N() : null;
+        return ($this->content instanceof DOMDocument) ? $this->content->C14N() : null;
     }
 
     /**

--- a/test/ReadabilityTest.php
+++ b/test/ReadabilityTest.php
@@ -117,4 +117,10 @@ class ReadabilityTest extends \PHPUnit_Framework_TestCase
         $this->expectExceptionMessage('Could not parse text.');
         $parser->parse('<html><body><p>hello</p></body></html>');
     }
+
+    public function testReadabilityCallGetContentWithNoContent()
+    {
+        $parser = new Readability(new Configuration());
+        $this->assertNull($parser->getContent());
+    }
 }


### PR DESCRIPTION
Hi Andres!

I have an error with new v1.1.1:
"Call to a member function C14N() on null"

You could reproduce like this:
	- try to parse a url like http://www.dailymotion.com/video/x6ga6qi that doesn't return any content
	- this throw an exception and the logs show  "[Parsing] Could not parse text, giving up :("
	- now, call ->getContent() with the same object readability

Previously, getContent would return "null" but now it call ->C14N() on a NULL object.

Thanks