### PR TITLE
Adds a missing import

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Then, create a Readability class and pass a Configuration class, feed the `parse
 ```php 
 use andreskrey\Readability\Readability;
 use andreskrey\Readability\Configuration;
+use andreskrey\Readability\ParseException;
 
 $readability = new Readability(new Configuration());
 


### PR DESCRIPTION
The example implies the use of `\ParseException`, but I think the author meant `andreskrey\Readability\ParseException`