### PR TITLE
dirname() breaks urls on windows

### DIFF
--- a/src/Readability.php
+++ b/src/Readability.php
@@ -604,10 +604,10 @@ class Readability
                 $pathBase = parse_url($url, PHP_URL_SCHEME) . '://' . parse_url($url, PHP_URL_HOST) . $this->dom->baseURI;
             } else {
                 // Otherwise just prepend the base to the actual path
-                $pathBase = parse_url($url, PHP_URL_SCHEME) . '://' . parse_url($url, PHP_URL_HOST) . dirname(parse_url($url, PHP_URL_PATH)) . '/' . rtrim($this->dom->baseURI, '/') . '/';
+                $pathBase = parse_url($url, PHP_URL_SCHEME) . '://' . parse_url($url, PHP_URL_HOST) . '/' . basename(parse_url($url, PHP_URL_PATH)) . '/' . rtrim($this->dom->baseURI, '/') . '/';
             }
         } else {
-            $pathBase = parse_url($url, PHP_URL_SCHEME) . '://' . parse_url($url, PHP_URL_HOST) . dirname(parse_url($url, PHP_URL_PATH)) . '/';
+            $pathBase = parse_url($url, PHP_URL_SCHEME) . '://' . parse_url($url, PHP_URL_HOST) . '/' . basename(parse_url($url, PHP_URL_PATH)) . '/';
         }
 
         $scheme = parse_url($pathBase, PHP_URL_SCHEME);


### PR DESCRIPTION
`dirname()` seems to be specifically meant for local filesystem operations. On windows, it adds a '\' at the beginning of the returned string, breaking URLs, since the resulted absolute URL looks like `http://site.tld/\dirname/` then.

`'/' . basename(...)` seems to work as a replacement that also works on Windows